### PR TITLE
Ruby OpenSSL Bug Fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:4.2.3
 # Install gem sass for grunt-contrib-sass
 RUN apt-get update -qq && apt-get install -y build-essential
 RUN apt-get install -y ruby
+RUN apt-get install -y libssl-dev ruby
 RUN gem install sass
 
 WORKDIR /home/seanjs


### PR DESCRIPTION
**Added Ruby dev dependencies to OpenSSL**

ERROR:  Loading command: install (LoadError)
	/usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so: symbol SSLv2_method, version OPENSSL_1.0.0 not defined in file libssl.so.1.0.0 with link time reference - /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so